### PR TITLE
fix: use of empty trailers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,6 +444,7 @@ impl http_body::Body for HttpBody {
             Poll::Ready(None) => match self.trailers.poll_unpin(cx) {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(None) => Poll::Ready(None),
+                Poll::Ready(Some(trailers)) if trailers.is_empty() => Poll::Ready(None),
                 Poll::Ready(Some(trailers)) => {
                     let trailers = try_fields_to_header_map(trailers)
                         .context("failed to convert trailer fields to header map")?;


### PR DESCRIPTION
This commit fixes a caused client error that would occur when trailers were supplied but empty -- i.e. a value like `Box::pin(async { Option::Some(vec![]) })` would cause a `client error (SendRequest)` in upstream libraries, as we tried to send a frame with no trailers (an empty headermap).

see: 
- https://github.com/wasmCloud/wasmCloud/issues/2990
- https://github.com/wasmCloud/wasmCloud/pull/4011

